### PR TITLE
Fixes for the undefined accountNumber + sequence bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ typings/
 
 \.idea/
 
+.vscode
+
 TODO\.md
 
 \dist

--- a/src/index.js
+++ b/src/index.js
@@ -362,7 +362,7 @@ CosmosDelegateTool.prototype.txCreateUndelegate = async function (
         throw new Error('txContext does not contain the source address (bech32)');
     }
 
-    const accountInfo = await this.getAccountInfo(txContext.bech32);
+    const accountInfo = await this.getAccountInfo(txContext);
     txContext.accountNumber = accountInfo.accountNumber;
     txContext.sequence = accountInfo.sequence;
 
@@ -390,7 +390,7 @@ CosmosDelegateTool.prototype.txCreateRedelegate = async function (
         throw new Error('txContext does not contain the source address (bech32)');
     }
 
-    const accountInfo = await this.getAccountInfo(txContext.bech32);
+    const accountInfo = await this.getAccountInfo(txContext);
     txContext.accountNumber = accountInfo.accountNumber;
     txContext.sequence = accountInfo.sequence;
 


### PR DESCRIPTION
In the undelegate + redelegate function you were passing only the bech32 value of the addr object vs the full object causing the getAccountInfo to error out on line 224 ```const url = `${this.resturl}/auth/accounts/${addr.bech32}`;``` resulting in the call to getAccountInfo within CosmosDelegateTool.prototype.txCreateRedelegate on line 393 returning undefined which are then mapped over to the next two lines 394 + 395. This is then used to call the...
 ```
return txs.createRedelegate(txContext,
        validatorSourceBech32,
        validatorDestBech32,
        sharesAmount,
        memo);
``` 
Which then throws the error we've all been seeing